### PR TITLE
Remove bundle config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,0 @@
----
-BUNDLE_PATH: ".vendor/"
-BUNDLE_JOBS: "17"
-BUNDLE_WITH: "development:system_tests:test"


### PR DESCRIPTION
The .bundle directory is in gitignore so it shouldn't be part of the repo.