### PR TITLE
Treat Variant[..., Undef] as optional

### DIFF
--- a/spec/puppet-lint/plugins/check_params_not_optional_with_undef/check_params_not_optional_with_undef_spec.rb
+++ b/spec/puppet-lint/plugins/check_params_not_optional_with_undef/check_params_not_optional_with_undef_spec.rb
@@ -52,6 +52,30 @@ describe 'params_not_optional_with_undef' do
       end
     end
 
+    context 'class definition with Variant containing Undef and undef value' do
+      let(:code) do
+        <<-EOS
+        class foo ( Variant[String, Undef] $bar = undef ) { }
+        EOS
+      end
+
+      it 'does not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'class definition with Variant containing multiple types and Undef' do
+      let(:code) do
+        <<-EOS
+        class foo ( Variant[String, Integer, Undef] $bar = undef ) { }
+        EOS
+      end
+
+      it 'does not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
     context 'class internal variable without empty strings' do
       let(:code) do
         <<-EOS


### PR DESCRIPTION
## Summary
- Fixes #5
- Adds `variant_with_undef?` helper that checks whether a `Variant` type contains `Undef` as a direct member (at depth 1)
- Skips the "not optional parameter defaults to undef" warning for such types, since `Variant[String, Undef]` is functionally equivalent to `Optional[String]`
- Adds test cases for `Variant[String, Undef]` and `Variant[String, Integer, Undef]`

## Test plan
- [x] All 17 specs pass (`bundle exec rake spec`)
- [x] Existing `Variant[String[0], Integer]` and `Variant[Any, Optional]` tests still warn correctly